### PR TITLE
83 fixing up lesson endpoints

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -120,7 +120,7 @@ DROP TABLE IF EXISTS Tafsir CASCADE;
 CREATE TABLE
     IF NOT EXISTS Tafsir (
         tafsir_id SERIAL PRIMARY KEY,
-        content TEXT NOT NULL,
+        tafsir_text TEXT NOT NULL,
         book INTEGER NOT NULL,
         verse_id INTEGER NOT NULL,
         visible BOOLEAN NOT NULL,

--- a/model/lesson.js
+++ b/model/lesson.js
@@ -1,5 +1,5 @@
 const utils = require("./utils");
-const verseInfo = require("./verseInfo")
+const verseInfo = require("./verseInfo");
 
 // Note: this list contains key value pairs of the attribute and types within the schema.
 const attributes = {
@@ -44,50 +44,40 @@ const attributes = {
  *  @schema LessonContent
  *  type: object
  *  required:
- *      - lessonInfo
- *      - lesson
+ *      - lesson_content
+ *      - lesson_id
+ *      - lesson_date
+ *      - start_verse
+ *      - end_verse
+ *      - source
  *  properties:
- *      lessonInfo:
+ *      lesson_content:
  *          type: array
  *          items:
+ *            type: object
  *            schema:
  *              $ref: "#/definitions/VerseInformation"
  *          description: collection of complete verse Information for verses assocaited with a lesson
- *          example: [{
- *                      verse: {
- *                          "verse_index": 1,
-                            "surah": 1,
-                            "verse_number": 1,
-                            "verse_text": "بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ"},
-                        reflectons:{
-                            "reflection_id": 1,
-                            "verse_id": 1,
-                            "title": "Bismillah",
-                            "reflection": "My First Reflection"},
-                        tafsirs:{"tafsir_id": 1,
-                            "content": "In the name of Allah, The Most Gracious, The Most Merciful",
-                            "book": 1,
-                            "verse_id": 1,
-                            "visible": false,
-                            "verse_index": 1,
-                            "surah": 1,
-                            "verse_number": 1,
-                            "verse_text": "بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ"},
-                        words:{"word": "بِسْمِ",
-                            "root_id": 1,
-                            "word_explaination": "An explanation of the basmalla goes here.",
-                            "visible": false,
-                            "root_word": "س م و",
-                            "meaning": "to be high",
-                            "word_id": 1}
-                    }]
- *      lesson:
- *          type: object
- *          items: 
- *             schema: 
- *               $ref: "#/definitions/Lesson"
- *          description: lesson details and information
- *          example: {"lesson_id":1,"lesson_date":"2021-10-30T00:00:00.000Z","start_verse":1,"end_verse":2,"source":"https://google.com"} 
+ *      lesson_id:
+ *          type: integer
+ *          description: to identify the lesson from others
+ *          example: 1
+ *      lesson_date:
+ *          type: date
+ *          description: to identify the day that the lesson was taught
+ *          example: 2021-10-30
+ *      start_verse:
+ *          type: integer
+ *          description: first verse in a lesson
+ *          example: 1
+ *      end_verse:
+ *          type: integer
+ *          description: last verse in a lesson
+ *          example: 3
+ *      source:
+ *          type: string
+ *          description: a URL to the lesson recording
+ *          example: "https://www.facebook.com/watch/live/?ref=watch_permalink&v=244235014324418"
  */
 async function createLesson(data) {
     // Frontend note: also add a feature where we guess that the
@@ -95,17 +85,21 @@ async function createLesson(data) {
     var invalid = utils.simpleValidation(data, {
         lesson_date: "date",
         source: "string",
+        surah_id: "string",
+        start_verse: "integer",
+        surah_id: "integer",
     });
     if (invalid) {
         return invalid;
     }
-
-    let start = data.start_verse ? data.start_verse : null;
-    let end = data.end_verse ? data.end_verse : null;
-
     var sql =
         "INSERT INTO Lesson (source, lesson_date, start_verse, end_verse) VALUES ($1, $2, $3, $4) RETURNING *;";
-    var params = [data.source, data.lesson_date, start, end];
+    var params = [
+        data.source,
+        data.lesson_date,
+        data.start_verse,
+        data.end_verse,
+    ];
     return await utils.create(
         sql,
         params,
@@ -190,33 +184,36 @@ async function getLessonById(data) {
 /*Fetches verses in a lesson based*/
 //ASSUMPTIONS: Verses in a Lesson are contigous
 async function getLessonVerses(data) {
-    let msg = "";
     let lesson = await getLessonById(data);
     if (!lesson.success) {
         return lesson;
     }
 
-    let lessonInfo = [];
-    if (lesson.data[0].start_verse == null || lesson.data[0].end_verse == null) {
-        msg = "Invalid start or end verse value"
-    } else {
-        let currentVerse = lesson.data[0].start_verse;
-        let numVerses = lesson.data[0].end_verse - lesson.data[0].start_verse;
-        for (let i = 0; i <= numVerses; i++) {
-            let temp = await verseInfo.getVerseInfo({ verse_id: currentVerse })
-            lessonInfo[i] = temp.data;
-            currentVerse++;
+    let lesson_content = [];
+    let errors = [];
+    let currentVerse = lesson.data[0].start_verse;
+    let num_verses = lesson.data[0].end_verse - lesson.data[0].start_verse;
+    for (let i = 0; i <= num_verses; i++) {
+        let temp = await verseInfo.getVerseInfo({ verse_id: currentVerse });
+        lesson_content[i] = temp.data;
+        if (temp.ecode != utils.errorEnum.NONE) {
+            errors.push(
+                `Error on verse with id ${temp.data.verse_index}: ${temp.error}`
+            );
         }
-        msg = "Successfully fetched complete lesson info"
+        currentVerse++;
+    }
+    if (errors.length == 0) {
+        errors = "Successfully fetched complete lesson info";
     }
 
     let res = utils.setResult(
-        { lesson: lesson.data, lessonInfo },
+        { ...lesson.data[0], num_verses, lesson_content },
         lesson.success,
-        msg,
+        errors,
         lesson.ecode
     );
-    return res
+    return res;
 }
 
 /** Update a lesson, requires all attributes of the lesson. */
@@ -225,12 +222,21 @@ async function updateLesson(data) {
         lesson_id: "integer",
         lesson_date: "date",
         source: "string",
+        start_verse: "integer",
+        end_verse: "integer",
     });
     if (invalid) {
         return invalid;
     }
-    let sql = "UPDATE Lesson SET source=$2, lesson_date=$3 WHERE lesson_id=$1";
-    var params = [data.lesson_id, data.source, data.lesson_date];
+    let sql =
+        "UPDATE Lesson SET source=$2, lesson_date=$3, start_verse=$4, end_verse=$5 WHERE lesson_id=$1";
+    var params = [
+        data.lesson_id,
+        data.source,
+        data.lesson_date,
+        data.start_verse,
+        data.end_verse,
+    ];
     return await utils.update(
         sql,
         params,
@@ -267,5 +273,5 @@ module.exports = {
     createLesson,
     updateLesson,
     deleteLesson,
-    getLessonVerses
+    getLessonVerses,
 };

--- a/model/quran.js
+++ b/model/quran.js
@@ -17,12 +17,12 @@ const utils = require("./utils");
  *          example: al-Fātihah
  */
 async function getChapters(data) {
-    let sql = "SELECT * FROM suras";
+    let sql = "SELECT * FROM surah";
     return await utils.retrieve(
         sql,
         [],
         new utils.Message({
-            success: `Successfully fetched all suras.`,
+            success: `Successfully fetched all surahs.`,
         })
     );
 }
@@ -36,19 +36,19 @@ async function getChapters(data) {
  *      - aya
  *      - text
  *  properties:
- *      index:
+ *      verse_index:
  *          type: integer
  *          description: the index of the verse in the quran
  *          example: 1
- *      sura:
+ *      surah:
  *          type: integer
  *          description: the sura id/number that the verse belongs to
  *          example: 1
- *      aya:
+ *      verse_number:
  *          type: integer
  *          description: the aya number within the surah
  *          example: 1
- *      text:
+ *      verse_text:
  *          type: string
  *          description: the text representation of the verse
  *          example: بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ
@@ -60,7 +60,7 @@ async function getChapterVerses(data) {
     if (invalid) {
         return invalid;
     }
-    let sql = "SELECT * FROM quran_text WHERE sura=$1";
+    let sql = "SELECT * FROM Verse WHERE surah=$1";
     var params = [data.sura_number];
     let verses = await utils.retrieve(
         sql,

--- a/model/verseInfo.js
+++ b/model/verseInfo.js
@@ -4,32 +4,43 @@ const utils = require("./utils");
  *  @schema VerseInformation
  *  type: object
  *  required:
- *      - verse
+ *      - verse_index
+ *      - surah
+ *      - verse_number
+ *      - verse_text
  *      - reflections
  *      - tafsirs
  *      - roots
  *  properties:
- *      verse: 
- *          type: array 
- *          items: 
- *              schema:
- *                  $ref: ""
- *          example: [{"verse_index": 1,"surah": 1,"verse_number": 1,"verse_text": "بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ"}]
+ *      verse_index:
+ *          type: integer
+ *          description: the index of the verse in the quran
+ *          example: 1
+ *      surah:
+ *          type: integer
+ *          description: the sura id/number that the verse belongs to
+ *          example: 1
+ *      verse_number:
+ *          type: integer
+ *          description: the aya number within the surah
+ *          example: 1
+ *      verse_text:
+ *          type: string
+ *          description: the text representation of the verse
+ *          example: بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ
  *      reflections:
  *          type: array
  *          items:
  *            schema:
  *              $ref: "#/definitions/Reflection"
  *          description: collection of reflections associated with a verse
- *          example: [{"reflection_id": 1,"verse_id": 1, "title": "Bismillah","reflection": "My First Reflection"}]
  *      tafsirs:
  *          type: array
  *          description: collection of tafsirs for a verse from different mufasirs
- *          example: [{"tafsir_id": 1,"content": "In the name of Allah, The Most Gracious, The Most Merciful","book": 1,"verse_id": 1, "visible": false,"verse_index": 1,"surah": 1,"verse_number": 1, "verse_text": "بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ"}]
+ *          example: [{"tafsir_id": 1,"tafsir_text": "In the name of Allah, The Most Gracious, The Most Merciful","book": 1,"verse_id": 1, "visible": false,"verse_index": 1,"surah": 1,"verse_number": 1, "verse_text": "بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ"}]
  *      words:
  *          type: array
  *          description: collection of root words for words in a verse
- *          example: [{"word": "بِسْمِ","root_id": 1,"word_explaination": "An explanation of the basmalla goes here.","visible": false, "root_word": "س م و","meaning": "to be high","word_id": 1}]
  *          items:
  *            schema:
  *              $ref: "#/definitions/verseWordExplanation"
@@ -76,7 +87,7 @@ async function verseInfoResult(data, verse, reflections, tafsirs, words) {
     }
     let res = utils.setResult(
         {
-            verse: verse.data,
+            ...verse.data[0],
             reflections: reflections.data,
             tafsirs: tafsirs.data,
             words: words.data,
@@ -85,7 +96,6 @@ async function verseInfoResult(data, verse, reflections, tafsirs, words) {
         error,
         ecode
     );
-    console.log(res);
     return res;
 }
 
@@ -135,7 +145,7 @@ async function getVerseTafsir(data) {
         return invalid;
     }
     let sql =
-        "SELECT * FROM Tafsir JOIN Verse ON Verse.verse_index=Tafsir.verse_id WHERE Tafsir.verse_id=$1";
+        "SELECT tafsir_id, tafsir_text, book, visible FROM Tafsir JOIN Verse ON Verse.verse_index=Tafsir.verse_id WHERE Tafsir.verse_id=$1";
     var params = [data.verse_id];
     return await utils.retrieve(
         sql,

--- a/run_backend.sh
+++ b/run_backend.sh
@@ -1,3 +1,3 @@
-# cd db; docker-compose down; docker-compose up --build -d;
-cd db; sh backup.sh;
+cd db; docker-compose down; docker-compose up -d;
+sleep 8;
 cd ..; nodemon index.js;

--- a/tests/lesson/lesson-info-tests.js
+++ b/tests/lesson/lesson-info-tests.js
@@ -6,35 +6,44 @@ const seedData = setup.seedData;
 
 function lessonInfoTests() {
     it("getting verse info linked to a lesson", async () => {
-        let lesson = seedData.Lesson[1]
-        let verseWord = seedData.VerseWord
-        let arabicWord = seedData.ArabicWord
-        let verses = seedData.Verse
-        let tafsirs = seedData.Tafsir
-        let reflections = seedData.Reflection
+        let lesson = seedData.Lesson[1];
+        let verseWord = seedData.VerseWord;
+        let arabicWord = seedData.ArabicWord;
+        let verses = seedData.Verse;
+        let tafsirs = seedData.Tafsir;
+        let reflections = seedData.Reflection;
 
-        let result = await apiGET("/lesson/2/verses")
-        expect(result.data.data.lessonInfo.length).toEqual(2)
+        let result = await apiGET("/lesson/2/verses");
+        expect(result.data.data.lesson_content.length).toEqual(2);
 
-        checkLessonMatch(result.data.data.lesson[0], lesson);
+        checkLessonMatch(result.data.data.lesson_id, lesson.lesson_id);
 
-        checkVerseMatch(result.data.data.lessonInfo[0].verse[0], verses[0])
-        checkVerseMatch(result.data.data.lessonInfo[1].verse[0], verses[1])
+        checkVerseMatch(result.data.data.lesson_content[0].verse[0], verses[0]);
+        checkVerseMatch(result.data.data.lesson_content[1].verse[0], verses[1]);
 
-        checkReflectionMatch(result.data.data.lessonInfo[0].reflections[0], reflections[0])
-        expect(result.data.data.lessonInfo[0].reflections.length).toEqual(2)
+        checkReflectionMatch(
+            result.data.data.lesson_content[0].reflections[0],
+            reflections[0]
+        );
+        expect(result.data.data.lesson_content[0].reflections.length).toEqual(
+            2
+        );
 
-        checkTafsirMatch(result.data.data.lessonInfo[0].tafsirs[0], tafsirs[0])
+        checkTafsirMatch(
+            result.data.data.lesson_content[0].tafsirs[0],
+            tafsirs[0]
+        );
 
-        checkWordMatch(result.data.data.lessonInfo[1].words[0], verseWord[1], arabicWord[2])
-
-    })
-
+        checkWordMatch(
+            result.data.data.lesson_content[1].words[0],
+            verseWord[1],
+            arabicWord[2]
+        );
+    });
 }
 function checkVerseMatch(t1, t2) {
     expect(t1.verse_index).toEqual(t2.verse_index);
-    expect(t1.verse_text).toEqual(t2.verse_text)
-
+    expect(t1.verse_text).toEqual(t2.verse_text);
 }
 function checkTafsirMatch(t1, t2) {
     expect(t1.tafsir_id).toEqual(t2.tafsir_id);
@@ -49,8 +58,8 @@ function checkWordMatch(t1, vw, aw) {
 }
 
 function checkReflectionMatch(t1, t2) {
-    expect(t1.reflection_id).toEqual(t2.reflection_id)
-    expect(t1.reflection).toEqual(t2.reflection)
+    expect(t1.reflection_id).toEqual(t2.reflection_id);
+    expect(t1.reflection).toEqual(t2.reflection);
 }
 
 function checkLessonMatch(lessonA, lessonB) {
@@ -61,5 +70,5 @@ function checkLessonMatch(lessonA, lessonB) {
 }
 
 module.exports = {
-    lessonInfoTests: lessonInfoTests
-}
+    lessonInfoTests,
+};

--- a/tests/lesson/lesson-info-tests.js
+++ b/tests/lesson/lesson-info-tests.js
@@ -18,8 +18,8 @@ function lessonInfoTests() {
 
         checkLessonMatch(result.data.data.lesson_id, lesson.lesson_id);
 
-        checkVerseMatch(result.data.data.lesson_content[0].verse[0], verses[0]);
-        checkVerseMatch(result.data.data.lesson_content[1].verse[0], verses[1]);
+        checkVerseMatch(result.data.data.lesson_content[0].verse_index, verses[0].verse_index);
+        checkVerseMatch(result.data.data.lesson_content[1].verse_index, verses[1].verse_index);
 
         checkReflectionMatch(
             result.data.data.lesson_content[0].reflections[0],

--- a/tests/lesson/lesson-info-tests.js
+++ b/tests/lesson/lesson-info-tests.js
@@ -38,7 +38,7 @@ function checkVerseMatch(t1, t2) {
 }
 function checkTafsirMatch(t1, t2) {
     expect(t1.tafsir_id).toEqual(t2.tafsir_id);
-    expect(t1.content).toEqual(t2.content);
+    expect(t1.tafsir_text).toEqual(t2.tafsir_text);
 }
 function checkWordMatch(t1, vw, aw) {
     expect(t1.root_id).toEqual(aw.root_id);

--- a/tests/lesson/lesson-tests.js
+++ b/tests/lesson/lesson-tests.js
@@ -43,6 +43,9 @@ function lessonTests() {
         let newlesson = {
             lesson_date: new moment(faker.date.past(100)).format("YYYY-MM-DD"),
             source: "randomWebsite.com/url_to_video",
+            surah_id: 1,
+            start_verse: 1,
+            end_verse: 2
         };
 
         let resp1 = await apiPOST(`/lesson`, newlesson);
@@ -55,7 +58,10 @@ function lessonTests() {
         let newlesson = {
             lesson_id: 1,
             lesson_date: new moment(faker.date.past(100)).format("YYYY-MM-DD"),
+            surah_id: 1,
             source: "randomWebsite.com/url_to_video",
+            start_verse: 1,
+            end_verse: 5
         };
 
         let resp1 = await apiGET(`/lesson/1`);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -20,7 +20,7 @@ const seedData = {
             surah_id: 1,
             lesson_date: new moment(faker.date.past(100)).format("YYYY-MM-DD"),
             start_verse: 1,
-            end_verse: 1,
+            end_verse: 3,
             source: "youtube.com/url_to_video",
         },
         {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -6,9 +6,18 @@ const moment = require("moment");
  * - 2 lessons
  */
 const seedData = {
+    Surah: [
+        {
+            surah_id: 1,
+            surah_number: 1,
+            name_complex: "Al-Fātiĥah",
+            name_arabic: "الفاتحة",
+        },
+    ],
     Lesson: [
         {
             lesson_id: 1,
+            surah_id: 1,
             lesson_date: new moment(faker.date.past(100)).format("YYYY-MM-DD"),
             start_verse: 1,
             end_verse: 1,
@@ -16,18 +25,11 @@ const seedData = {
         },
         {
             lesson_id: 2,
+            surah_id: 1,
             lesson_date: new moment(faker.date.past(100)).format("YYYY-MM-DD"),
             start_verse: 1,
             end_verse: 2,
             source: "facebook.com/url_to_video",
-        },
-    ],
-    Surah: [
-        {
-            surah_id: 1,
-            surah_number: 1,
-            name_complex: "Al-Fātiĥah",
-            name_arabic: "الفاتحة",
         },
     ],
     SurahInfo: [
@@ -172,7 +174,7 @@ const seedData = {
     Tafsir: [
         {
             tafsir_id: 1,
-            content:
+            tafsir_text:
                 "In the name of Allah, The Most Gracious, The Most Merciful",
             book: 1,
             verse_id: 1,

--- a/tests/verse-info-tests.js
+++ b/tests/verse-info-tests.js
@@ -14,7 +14,7 @@ function verseInfoTests() {
         const resp1 = await apiGET(`/verse/1`);
         expect(resp1.data.data.reflections[0]).toEqual(reflectionInfo);
         expect(resp1.data.data.reflections.length).toEqual(2);
-        expect(resp1.data.data.verse[0]).toEqual(verse);
+        expect(resp1.data.data.verse_index).toEqual(verse.verse_index);
 
         checkTafsirMatch(resp1.data.data.tafsirs[0], tafsirInfo);
         checkWordMatch(resp1.data.data.words[0], verseWord, arabicWord);

--- a/tests/verse-info-tests.js
+++ b/tests/verse-info-tests.js
@@ -37,7 +37,7 @@ function verseInfoTests() {
 
 function checkTafsirMatch(t1, t2) {
     expect(t1.tafsir_id).toEqual(t2.tafsir_id);
-    expect(t1.content).toEqual(t2.content);
+    expect(t1.tafsir_text).toEqual(t2.tafsir_text);
 }
 function checkWordMatch(t1, vw, aw) {
     expect(t1.root_id).toEqual(aw.root_id);


### PR DESCRIPTION
Note on fetching lesson content: I removed the check for null start and end verses. I realized it doesn't make sense not to force them to input those values when creating a new lesson. They can always update it later. However, I did put an error check for each of the verse information fetches. Now if there's an error whenever we are fetching a verse's information we will append that verse's error to a list of errors which will be returned in place of the success message.